### PR TITLE
Update Dockerfile

### DIFF
--- a/rs-container/docker_s1_ipf_l1/Dockerfile
+++ b/rs-container/docker_s1_ipf_l1/Dockerfile
@@ -7,7 +7,7 @@ FROM artifactory.coprs.esa-copernicus.eu/rs-docker/rs-core-base:${BRANCH} as bas
 # RS-597: Original image contains DEM files, however the resulting image is to big for the build pipe
 # to handle it. A new image without the DEM files are created that will assume the DEM files to be
 # on the shared disk.
-FROM artifactory.coprs.esa-copernicus.eu/cfi/processors/s1_l12:3.5.2-demless
+FROM artifactory.coprs.esa-copernicus.eu/cfi/processors/s1_l12:3.5.2-light
  
 ARG VERSION
 ARG COMMIT_ID
@@ -24,13 +24,6 @@ COPY --from=build /app/start.sh /app/start.sh
 COPY --from=base /log/log4j2.yml /log/log4j2.yml
 
 USER root:root
-
-# RS-597: Files from the DEM RPM are installed under IPF_CFG. We are expecting the content in the DEM 
-RUN mkdir -p /usr/local/conf
-RUN ln -s /shared/sentinel1/DEM /usr/local/conf/IPF_CFG
-
-# RS-783: Files from the IPF are expected in /usr/local/components/S1IPF
-RUN ln -s /usr/local/components/S1IPF_V00350/ /usr/local/components/S1IPF
  
 # Install java 11
 RUN yum install -y java-11-openjdk 


### PR DESCRIPTION
Remove all the WA as the Docker file is reworked.
In order to get the auxiliary data a PVC should be added in the RS add-on configuration. This will be tested first in the OPE configuration