### PR TITLE
#IPF S1 L1/L2 build with deactivate failed generation for anchore

### DIFF
--- a/.github/actions/build-ipf-container/action.yaml
+++ b/.github/actions/build-ipf-container/action.yaml
@@ -55,6 +55,7 @@ runs:
     with:
       image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
       acs-report-enable: true
+      fail-build: false
       severity-cutoff: critical
 
   - name: Upload Anchore scan SARIF report

--- a/rs-container/docker_s1_ipf_l1/Dockerfile
+++ b/rs-container/docker_s1_ipf_l1/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
  
 FROM artifactory.coprs.esa-copernicus.eu/rs-docker/rs-core-base:${BRANCH} as base
 
-
 FROM artifactory.coprs.esa-copernicus.eu/cfi/processors/s1_l12:3.8.0
  
 ARG VERSION

--- a/rs-container/docker_s1_ipf_l2/Dockerfile
+++ b/rs-container/docker_s1_ipf_l2/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
  
 FROM artifactory.coprs.esa-copernicus.eu/rs-docker/rs-core-base:${BRANCH} as base
 
-
 FROM artifactory.coprs.esa-copernicus.eu/cfi/processors/s1_l12:3.8.0
  
 ARG VERSION


### PR DESCRIPTION
Previous build failed due to "critical" alert from  anchore.
Deactivate build failure on critical detection. 